### PR TITLE
Create composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+  "name": "awarcrown/cybertron7",
+  "require": {
+    "php": "^8.1",
+    "symfony/symfony": "^6.0"
+  }
+}


### PR DESCRIPTION
your repository does not contain a composer.json file at the root or it is corrupted, this command will immediately fail.